### PR TITLE
EQTransformer using Colaboratory

### DIFF
--- a/EQTransformerviaGoogleColab.ipynb
+++ b/EQTransformerviaGoogleColab.ipynb
@@ -1,0 +1,1430 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "EQTransformerviaGoogleColab.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "authorship_tag": "ABX9TyPjPnkCUfkhQ/5rHwsUbUHa",
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/maihao14/EQTransformer/blob/colab/EQTransformerviaGoogleColab.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "4j6WYJvAHM5x"
+      },
+      "source": [
+        "# EQTransformer via Google Colab\n",
+        "**Author:** [Hao Mai](https://github.com/maihao14)<br>\n",
+        "**Date created:** 2021/11/14<br>\n",
+        "**Last modified:** 2021/11/14<br>\n",
+        "\n",
+        "## Description\n",
+        "\n",
+        "EQTransformer is an AI-based earthquake signal detector and phase (P&S) picker based on a deep neural network with an attention mechanism. It has a hierarchical architecture specifically designed for earthquake signals. EQTransformer has been trained on global seismic data and can perform detection and arrival time picking simultaneously and efficiently. In addition to the prediction probabilities, it can also provide estimated model uncertainties.\n",
+        "\n",
+        "The EQTransformer python 3 package includes modules for downloading continuous seismic data, preprocessing, performing earthquake signal detection, and phase (P & S) picking using pre-trained models, building and testing new models, and performing a simple phase association.\n",
+        "\n",
+        "**Developer:** [S. Mostafa Mousavi](https://github.com/smousavi05/EQTransformer#Contributing) <br>\n",
+        "\n",
+        "**Reference:** \n",
+        "\n",
+        "Mousavi, S.M., Ellsworth, W.L., Zhu, W., Chuang, L, Y., and Beroza, G, C. Earthquake transformer—an attentive deep-learning model for simultaneous earthquake detection and phase picking. Nat Commun 11, 3952 (2020). https://doi.org/10.1038/s41467-020-17591-w\n",
+        "\n",
+        "## Installation from Source\n",
+        "The sources for EQTransformer can be downloaded from the [Github repo](https://github.com/smousavi05/EQTransformer).\n",
+        "\n",
+        "### Prerequisite package: ObsPy\n",
+        "When ObsPy installed, restart the runtime.\n",
+        "\n",
+        "Menu -> Runtime -> Restart Runtime"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "7fAOnDDgLAH8",
+        "outputId": "531cd341-7486-4bc4-8612-2cb5e4da9c04"
+      },
+      "source": [
+        "!pip install obspy"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Requirement already satisfied: obspy in /usr/local/lib/python3.7/dist-packages (1.2.2)\n",
+            "Requirement already satisfied: lxml in /usr/local/lib/python3.7/dist-packages (from obspy) (4.2.6)\n",
+            "Requirement already satisfied: matplotlib>=1.1.0 in /usr/local/lib/python3.7/dist-packages (from obspy) (3.2.2)\n",
+            "Requirement already satisfied: requests in /usr/local/lib/python3.7/dist-packages (from obspy) (2.23.0)\n",
+            "Requirement already satisfied: scipy>=0.9.0 in /usr/local/lib/python3.7/dist-packages (from obspy) (1.4.1)\n",
+            "Requirement already satisfied: setuptools in /usr/local/lib/python3.7/dist-packages (from obspy) (57.4.0)\n",
+            "Requirement already satisfied: decorator in /usr/local/lib/python3.7/dist-packages (from obspy) (4.4.2)\n",
+            "Requirement already satisfied: numpy>=1.6.1 in /usr/local/lib/python3.7/dist-packages (from obspy) (1.19.2)\n",
+            "Requirement already satisfied: sqlalchemy in /usr/local/lib/python3.7/dist-packages (from obspy) (1.4.26)\n",
+            "Requirement already satisfied: future>=0.12.4 in /usr/local/lib/python3.7/dist-packages (from obspy) (0.16.0)\n",
+            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=1.1.0->obspy) (2.4.7)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=1.1.0->obspy) (0.11.0)\n",
+            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=1.1.0->obspy) (2.8.2)\n",
+            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib>=1.1.0->obspy) (1.3.2)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.1->matplotlib>=1.1.0->obspy) (1.15.0)\n",
+            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests->obspy) (1.24.3)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests->obspy) (3.0.4)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests->obspy) (2.10)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests->obspy) (2021.10.8)\n",
+            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.7/dist-packages (from sqlalchemy->obspy) (1.1.2)\n",
+            "Requirement already satisfied: importlib-metadata in /usr/local/lib/python3.7/dist-packages (from sqlalchemy->obspy) (4.8.2)\n",
+            "Requirement already satisfied: typing-extensions>=3.6.4 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->sqlalchemy->obspy) (3.7.4.3)\n",
+            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata->sqlalchemy->obspy) (3.6.0)\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "dxZQCYQNRa6U"
+      },
+      "source": [
+        "### Clone the public repository:\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "Frsmy3B_Jozr",
+        "outputId": "a4a8aaa8-4c07-4454-a5e8-a310660cc9bd"
+      },
+      "source": [
+        "! git clone https://github.com/smousavi05/EQTransformer"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Cloning into 'EQTransformer'...\n",
+            "remote: Enumerating objects: 2044, done.\u001b[K\n",
+            "remote: Counting objects: 100% (276/276), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (200/200), done.\u001b[K\n",
+            "remote: Total 2044 (delta 149), reused 152 (delta 75), pack-reused 1768\u001b[K\n",
+            "Receiving objects: 100% (2044/2044), 51.30 MiB | 28.20 MiB/s, done.\n",
+            "Resolving deltas: 100% (1106/1106), done.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eB-Kp7nCRlzX"
+      },
+      "source": [
+        "### Once you have a copy of the source, you can cd to EQTransformer directory "
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ebwwOiEBHREv",
+        "outputId": "aca46b1c-ee30-43ab-fe59-0343abdd730c"
+      },
+      "source": [
+        "%cd EQTransformer"
+      ],
+      "execution_count": 12,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "/content/EQTransformer\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "I9QsPaPQJIr9"
+      },
+      "source": [
+        "### Rewrite `setup.py`  :\n",
+        "```\n",
+        "'numpy==1.20.3' -> 'numpy==1.19.2'\n",
+        "```"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "l3lazYFsR2Ai"
+      },
+      "source": [
+        "### Install\n",
+        "\n",
+        "Need Restart Runtime again when this cell running is done. \n",
+        "\n",
+        "Menu -> Runtime -> Restart Runtime"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "ylznmBEbKoyO",
+        "outputId": "12d228ee-6321-45e3-9868-d45680cb13c9"
+      },
+      "source": [
+        "!pip install -e ."
+      ],
+      "execution_count": 4,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Obtaining file:///content/EQTransformer\n",
+            "Requirement already satisfied: pytest in /usr/local/lib/python3.7/dist-packages (from EQTransformer==0.1.61) (3.6.4)\n",
+            "Collecting numpy==1.19.2\n",
+            "  Downloading numpy-1.19.2-cp37-cp37m-manylinux2010_x86_64.whl (14.5 MB)\n",
+            "\u001b[K     |████████████████████████████████| 14.5 MB 34 kB/s \n",
+            "\u001b[?25hCollecting keyring>=15.1\n",
+            "  Downloading keyring-23.2.1-py3-none-any.whl (33 kB)\n",
+            "Collecting pkginfo>=1.4.2\n",
+            "  Downloading pkginfo-1.7.1-py2.py3-none-any.whl (25 kB)\n",
+            "Requirement already satisfied: scipy==1.4.1 in /usr/local/lib/python3.7/dist-packages (from EQTransformer==0.1.61) (1.4.1)\n",
+            "Collecting tensorflow==2.5.1\n",
+            "  Downloading tensorflow-2.5.1-cp37-cp37m-manylinux2010_x86_64.whl (454.4 MB)\n",
+            "\u001b[K     |████████████████████████████████| 454.4 MB 9.8 kB/s \n",
+            "\u001b[?25hCollecting keras==2.3.1\n",
+            "  Downloading Keras-2.3.1-py2.py3-none-any.whl (377 kB)\n",
+            "\u001b[K     |████████████████████████████████| 377 kB 59.6 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: matplotlib in /usr/local/lib/python3.7/dist-packages (from EQTransformer==0.1.61) (3.2.2)\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (from EQTransformer==0.1.61) (1.1.5)\n",
+            "Collecting tqdm==4.48.0\n",
+            "  Downloading tqdm-4.48.0-py2.py3-none-any.whl (67 kB)\n",
+            "\u001b[K     |████████████████████████████████| 67 kB 8.0 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: h5py==3.1.0 in /usr/local/lib/python3.7/dist-packages (from EQTransformer==0.1.61) (3.1.0)\n",
+            "Collecting obspy\n",
+            "  Downloading obspy-1.2.2.zip (24.7 MB)\n",
+            "\u001b[K     |████████████████████████████████| 24.7 MB 1.3 MB/s \n",
+            "\u001b[?25h  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
+            "  Installing backend dependencies ... \u001b[?25l\u001b[?25hdone\n",
+            "    Preparing wheel metadata ... \u001b[?25l\u001b[?25hdone\n",
+            "Requirement already satisfied: jupyter in /usr/local/lib/python3.7/dist-packages (from EQTransformer==0.1.61) (1.0.0)\n",
+            "Requirement already satisfied: cached-property in /usr/local/lib/python3.7/dist-packages (from h5py==3.1.0->EQTransformer==0.1.61) (1.5.2)\n",
+            "Requirement already satisfied: keras-preprocessing>=1.0.5 in /usr/local/lib/python3.7/dist-packages (from keras==2.3.1->EQTransformer==0.1.61) (1.1.2)\n",
+            "Requirement already satisfied: six>=1.9.0 in /usr/local/lib/python3.7/dist-packages (from keras==2.3.1->EQTransformer==0.1.61) (1.15.0)\n",
+            "Collecting keras-applications>=1.0.6\n",
+            "  Downloading Keras_Applications-1.0.8-py3-none-any.whl (50 kB)\n",
+            "\u001b[K     |████████████████████████████████| 50 kB 8.9 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: pyyaml in /usr/local/lib/python3.7/dist-packages (from keras==2.3.1->EQTransformer==0.1.61) (3.13)\n",
+            "Collecting flatbuffers~=1.12.0\n",
+            "  Downloading flatbuffers-1.12-py2.py3-none-any.whl (15 kB)\n",
+            "Collecting keras-nightly~=2.5.0.dev\n",
+            "  Downloading keras_nightly-2.5.0.dev2021032900-py2.py3-none-any.whl (1.2 MB)\n",
+            "\u001b[K     |████████████████████████████████| 1.2 MB 56.0 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: opt-einsum~=3.3.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow==2.5.1->EQTransformer==0.1.61) (3.3.0)\n",
+            "Requirement already satisfied: termcolor~=1.1.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow==2.5.1->EQTransformer==0.1.61) (1.1.0)\n",
+            "Requirement already satisfied: tensorboard~=2.5 in /usr/local/lib/python3.7/dist-packages (from tensorflow==2.5.1->EQTransformer==0.1.61) (2.7.0)\n",
+            "Collecting wrapt~=1.12.1\n",
+            "  Downloading wrapt-1.12.1.tar.gz (27 kB)\n",
+            "Requirement already satisfied: absl-py~=0.10 in /usr/local/lib/python3.7/dist-packages (from tensorflow==2.5.1->EQTransformer==0.1.61) (0.12.0)\n",
+            "Collecting tensorflow-estimator<2.6.0,>=2.5.0\n",
+            "  Downloading tensorflow_estimator-2.5.0-py2.py3-none-any.whl (462 kB)\n",
+            "\u001b[K     |████████████████████████████████| 462 kB 57.9 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: wheel~=0.35 in /usr/local/lib/python3.7/dist-packages (from tensorflow==2.5.1->EQTransformer==0.1.61) (0.37.0)\n",
+            "Requirement already satisfied: protobuf>=3.9.2 in /usr/local/lib/python3.7/dist-packages (from tensorflow==2.5.1->EQTransformer==0.1.61) (3.17.3)\n",
+            "Requirement already satisfied: astunparse~=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorflow==2.5.1->EQTransformer==0.1.61) (1.6.3)\n",
+            "Requirement already satisfied: gast==0.4.0 in /usr/local/lib/python3.7/dist-packages (from tensorflow==2.5.1->EQTransformer==0.1.61) (0.4.0)\n",
+            "Collecting grpcio~=1.34.0\n",
+            "  Downloading grpcio-1.34.1-cp37-cp37m-manylinux2014_x86_64.whl (4.0 MB)\n",
+            "\u001b[K     |████████████████████████████████| 4.0 MB 29.7 MB/s \n",
+            "\u001b[?25hCollecting typing-extensions~=3.7.4\n",
+            "  Downloading typing_extensions-3.7.4.3-py3-none-any.whl (22 kB)\n",
+            "Requirement already satisfied: google-pasta~=0.2 in /usr/local/lib/python3.7/dist-packages (from tensorflow==2.5.1->EQTransformer==0.1.61) (0.2.0)\n",
+            "Collecting SecretStorage>=3.2\n",
+            "  Downloading SecretStorage-3.3.1-py3-none-any.whl (15 kB)\n",
+            "Collecting jeepney>=0.4.2\n",
+            "  Downloading jeepney-0.7.1-py3-none-any.whl (54 kB)\n",
+            "\u001b[K     |████████████████████████████████| 54 kB 3.5 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: importlib-metadata>=3.6 in /usr/local/lib/python3.7/dist-packages (from keyring>=15.1->EQTransformer==0.1.61) (4.8.2)\n",
+            "Requirement already satisfied: zipp>=0.5 in /usr/local/lib/python3.7/dist-packages (from importlib-metadata>=3.6->keyring>=15.1->EQTransformer==0.1.61) (3.6.0)\n",
+            "Collecting cryptography>=2.0\n",
+            "  Downloading cryptography-35.0.0-cp36-abi3-manylinux_2_24_x86_64.whl (3.5 MB)\n",
+            "\u001b[K     |████████████████████████████████| 3.5 MB 48.5 MB/s \n",
+            "\u001b[?25hRequirement already satisfied: cffi>=1.12 in /usr/local/lib/python3.7/dist-packages (from cryptography>=2.0->SecretStorage>=3.2->keyring>=15.1->EQTransformer==0.1.61) (1.15.0)\n",
+            "Requirement already satisfied: pycparser in /usr/local/lib/python3.7/dist-packages (from cffi>=1.12->cryptography>=2.0->SecretStorage>=3.2->keyring>=15.1->EQTransformer==0.1.61) (2.21)\n",
+            "Requirement already satisfied: google-auth<3,>=1.6.3 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (1.35.0)\n",
+            "Requirement already satisfied: setuptools>=41.0.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (57.4.0)\n",
+            "Requirement already satisfied: werkzeug>=0.11.15 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (1.0.1)\n",
+            "Requirement already satisfied: tensorboard-data-server<0.7.0,>=0.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (0.6.1)\n",
+            "Requirement already satisfied: google-auth-oauthlib<0.5,>=0.4.1 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (0.4.6)\n",
+            "Requirement already satisfied: markdown>=2.6.8 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (3.3.4)\n",
+            "Requirement already satisfied: tensorboard-plugin-wit>=1.6.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (1.8.0)\n",
+            "Requirement already satisfied: requests<3,>=2.21.0 in /usr/local/lib/python3.7/dist-packages (from tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (2.23.0)\n",
+            "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (4.7.2)\n",
+            "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (0.2.8)\n",
+            "Requirement already satisfied: cachetools<5.0,>=2.0.0 in /usr/local/lib/python3.7/dist-packages (from google-auth<3,>=1.6.3->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (4.2.4)\n",
+            "Requirement already satisfied: requests-oauthlib>=0.7.0 in /usr/local/lib/python3.7/dist-packages (from google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (1.3.0)\n",
+            "Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /usr/local/lib/python3.7/dist-packages (from pyasn1-modules>=0.2.1->google-auth<3,>=1.6.3->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (0.4.8)\n",
+            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (1.24.3)\n",
+            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (2021.10.8)\n",
+            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (3.0.4)\n",
+            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests<3,>=2.21.0->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (2.10)\n",
+            "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.7/dist-packages (from requests-oauthlib>=0.7.0->google-auth-oauthlib<0.5,>=0.4.1->tensorboard~=2.5->tensorflow==2.5.1->EQTransformer==0.1.61) (3.1.1)\n",
+            "Requirement already satisfied: jupyter-console in /usr/local/lib/python3.7/dist-packages (from jupyter->EQTransformer==0.1.61) (5.2.0)\n",
+            "Requirement already satisfied: qtconsole in /usr/local/lib/python3.7/dist-packages (from jupyter->EQTransformer==0.1.61) (5.2.0)\n",
+            "Requirement already satisfied: nbconvert in /usr/local/lib/python3.7/dist-packages (from jupyter->EQTransformer==0.1.61) (5.6.1)\n",
+            "Requirement already satisfied: ipykernel in /usr/local/lib/python3.7/dist-packages (from jupyter->EQTransformer==0.1.61) (4.10.1)\n",
+            "Requirement already satisfied: notebook in /usr/local/lib/python3.7/dist-packages (from jupyter->EQTransformer==0.1.61) (5.3.1)\n",
+            "Requirement already satisfied: ipywidgets in /usr/local/lib/python3.7/dist-packages (from jupyter->EQTransformer==0.1.61) (7.6.5)\n",
+            "Requirement already satisfied: jupyter-client in /usr/local/lib/python3.7/dist-packages (from ipykernel->jupyter->EQTransformer==0.1.61) (5.3.5)\n",
+            "Requirement already satisfied: tornado>=4.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel->jupyter->EQTransformer==0.1.61) (5.1.1)\n",
+            "Requirement already satisfied: ipython>=4.0.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel->jupyter->EQTransformer==0.1.61) (5.5.0)\n",
+            "Requirement already satisfied: traitlets>=4.1.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel->jupyter->EQTransformer==0.1.61) (5.1.1)\n",
+            "Requirement already satisfied: decorator in /usr/local/lib/python3.7/dist-packages (from ipython>=4.0.0->ipykernel->jupyter->EQTransformer==0.1.61) (4.4.2)\n",
+            "Requirement already satisfied: pickleshare in /usr/local/lib/python3.7/dist-packages (from ipython>=4.0.0->ipykernel->jupyter->EQTransformer==0.1.61) (0.7.5)\n",
+            "Requirement already satisfied: prompt-toolkit<2.0.0,>=1.0.4 in /usr/local/lib/python3.7/dist-packages (from ipython>=4.0.0->ipykernel->jupyter->EQTransformer==0.1.61) (1.0.18)\n",
+            "Requirement already satisfied: simplegeneric>0.8 in /usr/local/lib/python3.7/dist-packages (from ipython>=4.0.0->ipykernel->jupyter->EQTransformer==0.1.61) (0.8.1)\n",
+            "Requirement already satisfied: pygments in /usr/local/lib/python3.7/dist-packages (from ipython>=4.0.0->ipykernel->jupyter->EQTransformer==0.1.61) (2.6.1)\n",
+            "Requirement already satisfied: pexpect in /usr/local/lib/python3.7/dist-packages (from ipython>=4.0.0->ipykernel->jupyter->EQTransformer==0.1.61) (4.8.0)\n",
+            "Requirement already satisfied: wcwidth in /usr/local/lib/python3.7/dist-packages (from prompt-toolkit<2.0.0,>=1.0.4->ipython>=4.0.0->ipykernel->jupyter->EQTransformer==0.1.61) (0.2.5)\n",
+            "Requirement already satisfied: nbformat>=4.2.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets->jupyter->EQTransformer==0.1.61) (5.1.3)\n",
+            "Requirement already satisfied: widgetsnbextension~=3.5.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets->jupyter->EQTransformer==0.1.61) (3.5.2)\n",
+            "Requirement already satisfied: ipython-genutils~=0.2.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets->jupyter->EQTransformer==0.1.61) (0.2.0)\n",
+            "Requirement already satisfied: jupyterlab-widgets>=1.0.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets->jupyter->EQTransformer==0.1.61) (1.0.2)\n",
+            "Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets->jupyter->EQTransformer==0.1.61) (2.6.0)\n",
+            "Requirement already satisfied: jupyter-core in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets->jupyter->EQTransformer==0.1.61) (4.9.1)\n",
+            "Requirement already satisfied: Send2Trash in /usr/local/lib/python3.7/dist-packages (from notebook->jupyter->EQTransformer==0.1.61) (1.8.0)\n",
+            "Requirement already satisfied: jinja2 in /usr/local/lib/python3.7/dist-packages (from notebook->jupyter->EQTransformer==0.1.61) (2.11.3)\n",
+            "Requirement already satisfied: terminado>=0.8.1 in /usr/local/lib/python3.7/dist-packages (from notebook->jupyter->EQTransformer==0.1.61) (0.12.1)\n",
+            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.7/dist-packages (from jupyter-client->ipykernel->jupyter->EQTransformer==0.1.61) (2.8.2)\n",
+            "Requirement already satisfied: pyzmq>=13 in /usr/local/lib/python3.7/dist-packages (from jupyter-client->ipykernel->jupyter->EQTransformer==0.1.61) (22.3.0)\n",
+            "Requirement already satisfied: ptyprocess in /usr/local/lib/python3.7/dist-packages (from terminado>=0.8.1->notebook->jupyter->EQTransformer==0.1.61) (0.7.0)\n",
+            "Requirement already satisfied: MarkupSafe>=0.23 in /usr/local/lib/python3.7/dist-packages (from jinja2->notebook->jupyter->EQTransformer==0.1.61) (2.0.1)\n",
+            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->EQTransformer==0.1.61) (2.4.7)\n",
+            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib->EQTransformer==0.1.61) (1.3.2)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib->EQTransformer==0.1.61) (0.11.0)\n",
+            "Requirement already satisfied: entrypoints>=0.2.2 in /usr/local/lib/python3.7/dist-packages (from nbconvert->jupyter->EQTransformer==0.1.61) (0.3)\n",
+            "Requirement already satisfied: bleach in /usr/local/lib/python3.7/dist-packages (from nbconvert->jupyter->EQTransformer==0.1.61) (4.1.0)\n",
+            "Requirement already satisfied: testpath in /usr/local/lib/python3.7/dist-packages (from nbconvert->jupyter->EQTransformer==0.1.61) (0.5.0)\n",
+            "Requirement already satisfied: defusedxml in /usr/local/lib/python3.7/dist-packages (from nbconvert->jupyter->EQTransformer==0.1.61) (0.7.1)\n",
+            "Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.7/dist-packages (from nbconvert->jupyter->EQTransformer==0.1.61) (0.8.4)\n",
+            "Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.7/dist-packages (from nbconvert->jupyter->EQTransformer==0.1.61) (1.5.0)\n",
+            "Requirement already satisfied: webencodings in /usr/local/lib/python3.7/dist-packages (from bleach->nbconvert->jupyter->EQTransformer==0.1.61) (0.5.1)\n",
+            "Requirement already satisfied: packaging in /usr/local/lib/python3.7/dist-packages (from bleach->nbconvert->jupyter->EQTransformer==0.1.61) (21.2)\n",
+            "Requirement already satisfied: lxml in /usr/local/lib/python3.7/dist-packages (from obspy->EQTransformer==0.1.61) (4.2.6)\n",
+            "Requirement already satisfied: future>=0.12.4 in /usr/local/lib/python3.7/dist-packages (from obspy->EQTransformer==0.1.61) (0.16.0)\n",
+            "Requirement already satisfied: sqlalchemy in /usr/local/lib/python3.7/dist-packages (from obspy->EQTransformer==0.1.61) (1.4.26)\n",
+            "Requirement already satisfied: pytz>=2017.2 in /usr/local/lib/python3.7/dist-packages (from pandas->EQTransformer==0.1.61) (2018.9)\n",
+            "Requirement already satisfied: atomicwrites>=1.0 in /usr/local/lib/python3.7/dist-packages (from pytest->EQTransformer==0.1.61) (1.4.0)\n",
+            "Requirement already satisfied: pluggy<0.8,>=0.5 in /usr/local/lib/python3.7/dist-packages (from pytest->EQTransformer==0.1.61) (0.7.1)\n",
+            "Requirement already satisfied: more-itertools>=4.0.0 in /usr/local/lib/python3.7/dist-packages (from pytest->EQTransformer==0.1.61) (8.10.0)\n",
+            "Requirement already satisfied: py>=1.5.0 in /usr/local/lib/python3.7/dist-packages (from pytest->EQTransformer==0.1.61) (1.11.0)\n",
+            "Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.7/dist-packages (from pytest->EQTransformer==0.1.61) (21.2.0)\n",
+            "Requirement already satisfied: qtpy in /usr/local/lib/python3.7/dist-packages (from qtconsole->jupyter->EQTransformer==0.1.61) (1.11.2)\n",
+            "Requirement already satisfied: greenlet!=0.4.17 in /usr/local/lib/python3.7/dist-packages (from sqlalchemy->obspy->EQTransformer==0.1.61) (1.1.2)\n",
+            "Building wheels for collected packages: wrapt, obspy\n",
+            "  Building wheel for wrapt (setup.py) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for wrapt: filename=wrapt-1.12.1-cp37-cp37m-linux_x86_64.whl size=68716 sha256=cf5e56d0b7f2af38b8481681327287db2c7ff9eeafe35f2ee2ed86868852f05c\n",
+            "  Stored in directory: /root/.cache/pip/wheels/62/76/4c/aa25851149f3f6d9785f6c869387ad82b3fd37582fa8147ac6\n",
+            "  Building wheel for obspy (PEP 517) ... \u001b[?25l\u001b[?25hdone\n",
+            "  Created wheel for obspy: filename=obspy-1.2.2-cp37-cp37m-linux_x86_64.whl size=21668550 sha256=f18e6f1585e151d8b8dd28d8a24531c5fc23f499c6d4ee47168e640fb13f1bc7\n",
+            "  Stored in directory: /root/.cache/pip/wheels/28/7e/ea/0a37d5f5001d096cf97d6527b60300badd2d0074449e89c736\n",
+            "Successfully built wrapt obspy\n",
+            "Installing collected packages: typing-extensions, numpy, jeepney, grpcio, cryptography, wrapt, tensorflow-estimator, SecretStorage, keras-nightly, keras-applications, flatbuffers, tqdm, tensorflow, pkginfo, obspy, keyring, keras, EQTransformer\n",
+            "  Attempting uninstall: typing-extensions\n",
+            "    Found existing installation: typing-extensions 3.10.0.2\n",
+            "    Uninstalling typing-extensions-3.10.0.2:\n",
+            "      Successfully uninstalled typing-extensions-3.10.0.2\n",
+            "  Attempting uninstall: numpy\n",
+            "    Found existing installation: numpy 1.19.5\n",
+            "    Uninstalling numpy-1.19.5:\n",
+            "      Successfully uninstalled numpy-1.19.5\n",
+            "  Attempting uninstall: grpcio\n",
+            "    Found existing installation: grpcio 1.41.1\n",
+            "    Uninstalling grpcio-1.41.1:\n",
+            "      Successfully uninstalled grpcio-1.41.1\n",
+            "  Attempting uninstall: wrapt\n",
+            "    Found existing installation: wrapt 1.13.3\n",
+            "    Uninstalling wrapt-1.13.3:\n",
+            "      Successfully uninstalled wrapt-1.13.3\n",
+            "  Attempting uninstall: tensorflow-estimator\n",
+            "    Found existing installation: tensorflow-estimator 2.7.0\n",
+            "    Uninstalling tensorflow-estimator-2.7.0:\n",
+            "      Successfully uninstalled tensorflow-estimator-2.7.0\n",
+            "  Attempting uninstall: flatbuffers\n",
+            "    Found existing installation: flatbuffers 2.0\n",
+            "    Uninstalling flatbuffers-2.0:\n",
+            "      Successfully uninstalled flatbuffers-2.0\n",
+            "  Attempting uninstall: tqdm\n",
+            "    Found existing installation: tqdm 4.62.3\n",
+            "    Uninstalling tqdm-4.62.3:\n",
+            "      Successfully uninstalled tqdm-4.62.3\n",
+            "  Attempting uninstall: tensorflow\n",
+            "    Found existing installation: tensorflow 2.7.0\n",
+            "    Uninstalling tensorflow-2.7.0:\n",
+            "      Successfully uninstalled tensorflow-2.7.0\n",
+            "  Attempting uninstall: keras\n",
+            "    Found existing installation: keras 2.7.0\n",
+            "    Uninstalling keras-2.7.0:\n",
+            "      Successfully uninstalled keras-2.7.0\n",
+            "  Running setup.py develop for EQTransformer\n",
+            "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "datascience 0.10.6 requires folium==0.2.1, but you have folium 0.8.3 which is incompatible.\n",
+            "albumentations 0.1.12 requires imgaug<0.2.7,>=0.2.5, but you have imgaug 0.2.9 which is incompatible.\u001b[0m\n",
+            "Successfully installed EQTransformer-0.1.61 SecretStorage-3.3.1 cryptography-35.0.0 flatbuffers-1.12 grpcio-1.34.1 jeepney-0.7.1 keras-2.3.1 keras-applications-1.0.8 keras-nightly-2.5.0.dev2021032900 keyring-23.2.1 numpy-1.19.2 obspy-1.2.2 pkginfo-1.7.1 tensorflow-2.5.1 tensorflow-estimator-2.5.0 tqdm-4.48.0 typing-extensions-3.7.4.3 wrapt-1.12.1\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "application/vnd.colab-display-data+json": {
+              "pip_warning": {
+                "packages": [
+                  "numpy"
+                ]
+              }
+            }
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "UjbTpeUpJ0TZ"
+      },
+      "source": [
+        "## Downloading Continuous Data\n",
+        "The following will download the information on the stations that are available based on your search criteria:\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "-ivpA28GLYqF",
+        "outputId": "a41d0b6f-bbba-43d0-b6ff-922736b828f4"
+      },
+      "source": [
+        "import os\n",
+        "json_basepath = os.path.join(os.getcwd(),\"json/station_list.json\")\n",
+        "\n",
+        "from EQTransformer.utils.downloader import makeStationList\n",
+        "\n",
+        "makeStationList(json_path=json_basepath, client_list=[\"SCEDC\"], min_lat=35.50, max_lat=35.60, min_lon=-117.80, max_lon=-117.40, start_time=\"2019-09-01 00:00:00.00\", end_time=\"2019-09-03 00:00:00.00\", channel_list=[\"HH[ZNE]\", \"HH[Z21]\", \"BH[ZNE]\"], filter_network=[\"SY\"], filter_station=[])"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "GS--CA06\n",
+            "GS--CA10\n",
+            "PB--B921\n",
+            "ZY--SV08\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "B9KgQV4gXRpn"
+      },
+      "source": [
+        "The above function will generate station_list.json file containing the station information. Next, you can use this file and download 1 day of data for the available stations at Ridgecrest, California from Southern California Earthquake Data Center or IRIS using the following:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "c2qUK1YPNdv8",
+        "outputId": "e4ccb36a-fe96-49c4-bc6f-af5babcc62a6"
+      },
+      "source": [
+        "from EQTransformer.utils.downloader import downloadMseeds\n",
+        "downloadMseeds(client_list=[\"SCEDC\", \"IRIS\"], stations_json=json_basepath, output_dir=\"downloads_mseeds\", min_lat=35.50, max_lat=35.60, min_lon=-117.80, max_lon=-117.40, start_time=\"2019-09-01 00:00:00.00\", end_time=\"2019-09-03 00:00:00.00\", chunk_size=1, channel_list=[], n_processor=2)"
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:36:36,486] - obspy.clients.fdsn.mass_downloader - INFO: Initializing FDSN client(s) for SCEDC, IRIS.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "####### There are 4 stations in the list. #######\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:36:36,687] - obspy.clients.fdsn.mass_downloader - INFO: Successfully initialized 2 client(s): SCEDC, IRIS.\n",
+            "[2021-11-14 22:36:36,690] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:36:36,694] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Requesting unreliable availability.\n",
+            "[2021-11-14 22:36:36,690] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:36:36,699] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Requesting unreliable availability.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "======= Working on CA06 station.\n",
+            "======= Working on CA10 station.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:36:36,948] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully requested availability (0.25 seconds)\n",
+            "[2021-11-14 22:36:36,950] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully requested availability (0.25 seconds)\n",
+            "[2021-11-14 22:36:36,959] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Found 0 stations (0 channels).\n",
+            "[2021-11-14 22:36:36,964] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - No data available.\n",
+            "[2021-11-14 22:36:36,966] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:36:36,956] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:36:36,967] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Requesting reliable availability.\n",
+            "[2021-11-14 22:36:36,969] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Will attempt to download data from 1 stations.\n",
+            "[2021-11-14 22:36:36,975] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels before downloading: NEEDS_DOWNLOADING\n",
+            "[2021-11-14 22:36:37,052] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Successfully requested availability (0.08 seconds)\n",
+            "[2021-11-14 22:36:37,054] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Found 0 stations (0 channels).\n",
+            "[2021-11-14 22:36:37,055] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No data available.\n",
+            "[2021-11-14 22:36:37,057] - obspy.clients.fdsn.mass_downloader - INFO: ============================== Final report\n",
+            "[2021-11-14 22:36:37,059] - obspy.clients.fdsn.mass_downloader - INFO: 0 MiniSEED files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:36:37,061] - obspy.clients.fdsn.mass_downloader - INFO: 0 StationXML files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:36:37,064] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:36:37,065] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:36:37,067] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:36:37,069] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:36:37,070] - obspy.clients.fdsn.mass_downloader - INFO: Downloaded 0.0 MB in total.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "** done with --> CA10 -- GS -- 2019-09-01\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:36:41,684] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:36:42,251] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:36:42,260] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:36:42,261] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Launching basic QC checks...\n",
+            "[2021-11-14 22:36:42,292] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Downloaded 28.2 MB [5462.06 KB/sec] of data, 0.0 MB of which were discarded afterwards.\n",
+            "[2021-11-14 22:36:42,293] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels after downloading: DOWNLOADED\n",
+            "[2021-11-14 22:36:51,177] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 'downloads_mseedsxml/CA06/GS.CA06.xml'.\n",
+            "[2021-11-14 22:36:51,184] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Downloaded 1 station files [0.1 MB] in 8.9 seconds [7.84 KB/sec].\n",
+            "[2021-11-14 22:36:51,190] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 1\n",
+            "[2021-11-14 22:36:51,191] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Requesting reliable availability.\n",
+            "[2021-11-14 22:36:51,399] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Successfully requested availability (0.21 seconds)\n",
+            "[2021-11-14 22:36:51,404] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:36:51,406] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No new data available after discarding already downloaded data.\n",
+            "[2021-11-14 22:36:51,409] - obspy.clients.fdsn.mass_downloader - INFO: ============================== Final report\n",
+            "[2021-11-14 22:36:51,411] - obspy.clients.fdsn.mass_downloader - INFO: 0 MiniSEED files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:36:51,414] - obspy.clients.fdsn.mass_downloader - INFO: 0 StationXML files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:36:51,416] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 3 MiniSEED files [28.2 MB].\n",
+            "[2021-11-14 22:36:51,418] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 1 StationXML files [0.1 MB].\n",
+            "[2021-11-14 22:36:51,419] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:36:51,421] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:36:51,422] - obspy.clients.fdsn.mass_downloader - INFO: Downloaded 28.2 MB in total.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "** done with --> CA06 -- GS -- 2019-09-01\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:37:04,085] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:37:04,087] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Requesting unreliable availability.\n",
+            "[2021-11-14 22:37:04,369] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully requested availability (0.28 seconds)\n",
+            "[2021-11-14 22:37:04,372] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Found 0 stations (0 channels).\n",
+            "[2021-11-14 22:37:04,374] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - No data available.\n",
+            "[2021-11-14 22:37:04,375] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:37:04,377] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Requesting reliable availability.\n",
+            "[2021-11-14 22:37:04,462] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Successfully requested availability (0.08 seconds)\n",
+            "[2021-11-14 22:37:04,463] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Found 0 stations (0 channels).\n",
+            "[2021-11-14 22:37:04,466] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No data available.\n",
+            "[2021-11-14 22:37:04,467] - obspy.clients.fdsn.mass_downloader - INFO: ============================== Final report\n",
+            "[2021-11-14 22:37:04,469] - obspy.clients.fdsn.mass_downloader - INFO: 0 MiniSEED files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:37:04,471] - obspy.clients.fdsn.mass_downloader - INFO: 0 StationXML files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:37:04,473] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:37:04,474] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:37:04,476] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:37:04,478] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:37:04,480] - obspy.clients.fdsn.mass_downloader - INFO: Downloaded 0.0 MB in total.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "** done with --> CA10 -- GS -- 2019-09-02\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:37:16,439] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:37:16,440] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Requesting unreliable availability.\n",
+            "[2021-11-14 22:37:16,705] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully requested availability (0.26 seconds)\n",
+            "[2021-11-14 22:37:16,708] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:37:16,711] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Will attempt to download data from 1 stations.\n",
+            "[2021-11-14 22:37:16,713] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels before downloading: NEEDS_DOWNLOADING\n",
+            "[2021-11-14 22:37:18,958] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:37:26,148] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:37:27,254] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:37:27,256] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Launching basic QC checks...\n",
+            "[2021-11-14 22:37:27,285] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Downloaded 28.5 MB [2769.50 KB/sec] of data, 0.0 MB of which were discarded afterwards.\n",
+            "[2021-11-14 22:37:27,287] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels after downloading: DOWNLOADED\n",
+            "[2021-11-14 22:37:27,293] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - No station information to download.\n",
+            "[2021-11-14 22:37:27,296] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 1\n",
+            "[2021-11-14 22:37:27,298] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Requesting reliable availability.\n",
+            "[2021-11-14 22:37:27,473] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Successfully requested availability (0.17 seconds)\n",
+            "[2021-11-14 22:37:27,476] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:37:27,480] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No new data available after discarding already downloaded data.\n",
+            "[2021-11-14 22:37:27,484] - obspy.clients.fdsn.mass_downloader - INFO: ============================== Final report\n",
+            "[2021-11-14 22:37:27,485] - obspy.clients.fdsn.mass_downloader - INFO: 0 MiniSEED files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:37:27,486] - obspy.clients.fdsn.mass_downloader - INFO: 1 StationXML files [0.1 MB] already existed.\n",
+            "[2021-11-14 22:37:27,487] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 3 MiniSEED files [28.5 MB].\n",
+            "[2021-11-14 22:37:27,488] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:37:27,490] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:37:27,491] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:37:27,492] - obspy.clients.fdsn.mass_downloader - INFO: Downloaded 28.5 MB in total.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "** done with --> CA06 -- GS -- 2019-09-02\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:37:29,489] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:37:29,490] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Requesting unreliable availability.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "======= Working on B921 station.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:37:29,724] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully requested availability (0.23 seconds)\n",
+            "[2021-11-14 22:37:29,760] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:37:29,762] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Will attempt to download data from 1 stations.\n",
+            "[2021-11-14 22:37:29,765] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels before downloading: NEEDS_DOWNLOADING\n",
+            "[2021-11-14 22:37:31,870] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:37:38,715] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:37:38,722] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:37:38,724] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Launching basic QC checks...\n",
+            "[2021-11-14 22:37:38,747] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Downloaded 27.1 MB [3103.84 KB/sec] of data, 0.0 MB of which were discarded afterwards.\n",
+            "[2021-11-14 22:37:38,749] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels after downloading: DOWNLOADED\n",
+            "[2021-11-14 22:37:45,065] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 'downloads_mseedsxml/B921/PB.B921.xml'.\n",
+            "[2021-11-14 22:37:45,069] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Downloaded 1 station files [0.0 MB] in 6.3 seconds [3.99 KB/sec].\n",
+            "[2021-11-14 22:37:45,072] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 1\n",
+            "[2021-11-14 22:37:45,073] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Requesting reliable availability.\n",
+            "[2021-11-14 22:37:45,446] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Successfully requested availability (0.37 seconds)\n",
+            "[2021-11-14 22:37:45,474] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:37:45,475] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No new data available after discarding already downloaded data.\n",
+            "[2021-11-14 22:37:45,478] - obspy.clients.fdsn.mass_downloader - INFO: ============================== Final report\n",
+            "[2021-11-14 22:37:45,482] - obspy.clients.fdsn.mass_downloader - INFO: 0 MiniSEED files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:37:45,483] - obspy.clients.fdsn.mass_downloader - INFO: 0 StationXML files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:37:45,484] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 3 MiniSEED files [27.1 MB].\n",
+            "[2021-11-14 22:37:45,485] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 1 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:37:45,487] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:37:45,488] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:37:45,489] - obspy.clients.fdsn.mass_downloader - INFO: Downloaded 27.1 MB in total.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "** done with --> B921 -- PB -- 2019-09-01\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:37:54,514] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:37:54,515] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Requesting unreliable availability.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "======= Working on SV08 station.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:37:54,746] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully requested availability (0.23 seconds)\n",
+            "[2021-11-14 22:37:54,748] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:37:54,751] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Will attempt to download data from 1 stations.\n",
+            "[2021-11-14 22:37:54,754] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels before downloading: NEEDS_DOWNLOADING\n",
+            "[2021-11-14 22:38:12,514] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:38:12,525] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Requesting unreliable availability.\n",
+            "[2021-11-14 22:38:12,774] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully requested availability (0.24 seconds)\n",
+            "[2021-11-14 22:38:12,823] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:38:12,824] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Will attempt to download data from 1 stations.\n",
+            "[2021-11-14 22:38:12,834] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels before downloading: NEEDS_DOWNLOADING\n",
+            "[2021-11-14 22:38:13,284] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:38:13,311] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:38:13,312] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:38:13,316] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Launching basic QC checks...\n",
+            "[2021-11-14 22:38:13,342] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Downloaded 27.3 MB [1504.05 KB/sec] of data, 0.0 MB of which were discarded afterwards.\n",
+            "[2021-11-14 22:38:13,344] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels after downloading: DOWNLOADED\n",
+            "[2021-11-14 22:38:15,020] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:38:15,255] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:38:17,689] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:38:17,691] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Launching basic QC checks...\n",
+            "[2021-11-14 22:38:17,713] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Downloaded 27.1 MB [5750.40 KB/sec] of data, 0.0 MB of which were discarded afterwards.\n",
+            "[2021-11-14 22:38:17,714] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels after downloading: DOWNLOADED\n",
+            "[2021-11-14 22:38:17,719] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - No station information to download.\n",
+            "[2021-11-14 22:38:17,720] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 1\n",
+            "[2021-11-14 22:38:17,723] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Requesting reliable availability.\n",
+            "[2021-11-14 22:38:18,151] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Successfully requested availability (0.42 seconds)\n",
+            "[2021-11-14 22:38:18,181] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:38:18,185] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No new data available after discarding already downloaded data.\n",
+            "[2021-11-14 22:38:18,186] - obspy.clients.fdsn.mass_downloader - INFO: ============================== Final report\n",
+            "[2021-11-14 22:38:18,189] - obspy.clients.fdsn.mass_downloader - INFO: 0 MiniSEED files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:38:18,190] - obspy.clients.fdsn.mass_downloader - INFO: 1 StationXML files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:38:18,194] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 3 MiniSEED files [27.1 MB].\n",
+            "[2021-11-14 22:38:18,196] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:38:18,199] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:38:18,201] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:38:18,206] - obspy.clients.fdsn.mass_downloader - INFO: Downloaded 27.1 MB in total.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "** done with --> B921 -- PB -- 2019-09-02\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:38:21,294] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 'downloads_mseedsxml/SV08/ZY.SV08.xml'.\n",
+            "[2021-11-14 22:38:21,302] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Downloaded 1 station files [0.1 MB] in 7.9 seconds [8.49 KB/sec].\n",
+            "[2021-11-14 22:38:21,303] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 1\n",
+            "[2021-11-14 22:38:21,306] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Requesting reliable availability.\n",
+            "[2021-11-14 22:38:21,391] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No data available for request.\n",
+            "[2021-11-14 22:38:21,392] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No data available.\n",
+            "[2021-11-14 22:38:21,393] - obspy.clients.fdsn.mass_downloader - INFO: ============================== Final report\n",
+            "[2021-11-14 22:38:21,396] - obspy.clients.fdsn.mass_downloader - INFO: 0 MiniSEED files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:38:21,398] - obspy.clients.fdsn.mass_downloader - INFO: 0 StationXML files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:38:21,400] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 3 MiniSEED files [27.3 MB].\n",
+            "[2021-11-14 22:38:21,402] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 1 StationXML files [0.1 MB].\n",
+            "[2021-11-14 22:38:21,405] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:38:21,409] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:38:21,413] - obspy.clients.fdsn.mass_downloader - INFO: Downloaded 27.3 MB in total.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "** done with --> SV08 -- ZY -- 2019-09-01\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "[2021-11-14 22:38:49,444] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 0\n",
+            "[2021-11-14 22:38:49,446] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Requesting unreliable availability.\n",
+            "[2021-11-14 22:38:49,698] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully requested availability (0.25 seconds)\n",
+            "[2021-11-14 22:38:49,703] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Found 1 stations (3 channels).\n",
+            "[2021-11-14 22:38:49,705] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Will attempt to download data from 1 stations.\n",
+            "[2021-11-14 22:38:49,708] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels before downloading: NEEDS_DOWNLOADING\n",
+            "[2021-11-14 22:38:51,310] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:39:14,509] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:39:14,543] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Successfully downloaded 1 channels (of 1)\n",
+            "[2021-11-14 22:39:14,545] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Launching basic QC checks...\n",
+            "[2021-11-14 22:39:14,573] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Downloaded 27.6 MB [1137.70 KB/sec] of data, 0.0 MB of which were discarded afterwards.\n",
+            "[2021-11-14 22:39:14,574] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Status for 3 time intervals/channels after downloading: DOWNLOADED\n",
+            "[2021-11-14 22:39:14,583] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - No station information to download.\n",
+            "[2021-11-14 22:39:14,585] - obspy.clients.fdsn.mass_downloader - INFO: Total acquired or preexisting stations: 1\n",
+            "[2021-11-14 22:39:14,589] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Requesting reliable availability.\n",
+            "[2021-11-14 22:39:14,767] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No data available for request.\n",
+            "[2021-11-14 22:39:14,769] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - No data available.\n",
+            "[2021-11-14 22:39:14,771] - obspy.clients.fdsn.mass_downloader - INFO: ============================== Final report\n",
+            "[2021-11-14 22:39:14,772] - obspy.clients.fdsn.mass_downloader - INFO: 0 MiniSEED files [0.0 MB] already existed.\n",
+            "[2021-11-14 22:39:14,774] - obspy.clients.fdsn.mass_downloader - INFO: 1 StationXML files [0.1 MB] already existed.\n",
+            "[2021-11-14 22:39:14,776] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 3 MiniSEED files [27.6 MB].\n",
+            "[2021-11-14 22:39:14,777] - obspy.clients.fdsn.mass_downloader - INFO: Client 'SCEDC' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:39:14,778] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 MiniSEED files [0.0 MB].\n",
+            "[2021-11-14 22:39:14,780] - obspy.clients.fdsn.mass_downloader - INFO: Client 'IRIS' - Acquired 0 StationXML files [0.0 MB].\n",
+            "[2021-11-14 22:39:14,781] - obspy.clients.fdsn.mass_downloader - INFO: Downloaded 27.6 MB in total.\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "** done with --> SV08 -- ZY -- 2019-09-02\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ANnEewb-LtZB"
+      },
+      "source": [
+        "# Detection and Picking\n",
+        "To perform detection & picking you need a pre-trained model of EQTransformer which you can get from folder: `EQTransformer/ModelsAndSampleData/`.\n",
+        "\n",
+        "\n",
+        "EQTransformer provides two different option for performing the detection & picking on the continuous data:\n",
+        "## Option (I) using pre-processed data (hdf5 files):\n",
+        "This option is recommended for smaller periods (a few days to a month). This allows you to test the performance and explore the effects of different parameters while the provided hdf5 file makes it easy to access the waveforms.\n",
+        "\n",
+        "For this option, you first need to convert your MiniSeed files for each station into 1-min long Numpy arrays in a single hdf5 file and generated a CSV file containing the list of traces in the hdf5 file. You can do this using the following command:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "b0iKTNHLLdjT",
+        "outputId": "841a0bfc-beb9-4d51-e056-f609f240f851"
+      },
+      "source": [
+        "from EQTransformer.utils.hdf5_maker import preprocessor\n",
+        "\n",
+        "preprocessor(preproc_dir=\"preproc\", mseed_dir='downloads_mseeds', stations_json=json_basepath, overlap=0.3, n_processor=2)"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "============ Station CA06 has 2 chunks of data.\n",
+            "============ Station B921 has 2 chunks of data.\n",
+            "  * CA06 (1) .. 20190901 --> 20190902 .. 3 components .. sampling rate: 100.0\n",
+            "  * B921 (1) .. 20190901 --> 20190902 .. 3 components .. sampling rate: 100.0\n",
+            "  * B921 (2) .. 20190902 --> 20190903 .. 3 components .. sampling rate: 100.0\n",
+            "  * CA06 (2) .. 20190902 --> 20190903 .. 3 components .. sampling rate: 100.0\n",
+            " Station CA06 had 2 chuncks of data\n",
+            "4112 slices were written, 4114.0 were expected.\n",
+            "Number of 1-components: 0. Number of 2-components: 0. Number of 3-components: 2.\n",
+            "Original samplieng rate: 100.0.\n",
+            "============ Station SV08 has 2 chunks of data.\n",
+            "  * SV08 (1) .. 20190901 --> 20190902 .. 3 components .. sampling rate: 100.0 Station B921 had 2 chuncks of data\n",
+            "\n",
+            "4112 slices were written, 4114.0 were expected.\n",
+            "Number of 1-components: 0. Number of 2-components: 0. Number of 3-components: 2.\n",
+            "Original samplieng rate: 100.0.\n",
+            "  * SV08 (2) .. 20190902 --> 20190903 .. 3 components .. sampling rate: 100.0\n",
+            " Station SV08 had 2 chuncks of data\n",
+            "4112 slices were written, 4114.0 were expected.\n",
+            "Number of 1-components: 0. Number of 2-components: 0. Number of 3-components: 2.\n",
+            "Original samplieng rate: 100.0.\n"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "OMA5Eq5CLsFS",
+        "outputId": "024c2de3-a0c0-4d6b-85f4-22e2e5de8f2b"
+      },
+      "source": [
+        "from EQTransformer.core.predictor import predictor\n",
+        "\n",
+        "predictor(input_dir= 'downloads_mseeds_processed_hdfs', input_model='EQTransformer/ModelsAndSampleData/EqT_model.h5', output_dir='detections', detection_threshold=0.3, P_threshold=0.1, S_threshold=0.1, number_of_plots=100, plot_mode='time')"
+      ],
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "============================================================================\n",
+            "Running EqTransformer  0.1.61\n",
+            " *** Loading the model ...\n",
+            "*** Loading is complete!\n",
+            "============================================================================\n",
+            " *** /content/detections already exists!\n",
+            " --> Type (Yes or y) to create a new empty directory! otherwise it will overwrite!   y\n",
+            "######### There are files for 3 stations in downloads_mseeds_processed_hdfs directory. #########\n",
+            "========= Started working on B921, 1 out of 3 ...\n",
+            "\n",
+            "\n",
+            "\n",
+            "  0%|                                                                         | 0/9 [00:00<?, ?it/s]\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            " 22%|██████████████▍                                                  | 2/9 [01:03<03:41, 31.63s/it]\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            " 33%|█████████████████████▋                                           | 3/9 [01:15<02:34, 25.68s/it]\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            " 44%|████████████████████████████▉                                    | 4/9 [01:26<01:47, 21.51s/it]\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            " 56%|████████████████████████████████████                             | 5/9 [01:38<01:14, 18.63s/it]\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            " 67%|███████████████████████████████████████████▎                     | 6/9 [01:50<00:49, 16.52s/it]\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            " 78%|██████████████████████████████████████████████████▌              | 7/9 [02:01<00:29, 14.99s/it]\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            " 89%|█████████████████████████████████████████████████████████▊       | 8/9 [02:13<00:14, 14.14s/it]\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "100%|█████████████████████████████████████████████████████████████████| 9/9 [02:25<00:00, 13.36s/it]\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            " *** Finished the prediction in: 0 hours and 2 minutes and 28.85 seconds.\n",
+            " *** Detected: 2724 events.\n",
+            " *** Wrote the results into --> \" /content/detections/B921_outputs \"\n",
+            "========= Started working on CA06, 2 out of 3 ...\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            "  0%|                                                                         | 0/9 [00:00<?, ?it/s]\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            " 22%|██████████████▍                                                  | 2/9 [00:56<03:16, 28.05s/it]\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            " 33%|█████████████████████▋                                           | 3/9 [01:07<02:17, 22.98s/it]\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            " 44%|████████████████████████████▉                                    | 4/9 [01:19<01:38, 19.66s/it]\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            " 56%|████████████████████████████████████                             | 5/9 [01:31<01:09, 17.35s/it]\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            " 67%|███████████████████████████████████████████▎                     | 6/9 [01:53<00:56, 18.86s/it]\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            " 78%|██████████████████████████████████████████████████▌              | 7/9 [02:15<00:39, 19.84s/it]\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            " 89%|█████████████████████████████████████████████████████████▊       | 8/9 [02:27<00:17, 17.53s/it]\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            "100%|█████████████████████████████████████████████████████████████████| 9/9 [02:50<00:00, 19.03s/it]\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            " *** Finished the prediction in: 0 hours and 2 minutes and 56.12 seconds.\n",
+            " *** Detected: 2688 events.\n",
+            " *** Wrote the results into --> \" /content/detections/CA06_outputs \"\n",
+            "========= Started working on SV08, 3 out of 3 ...\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            "  0%|                                                                         | 0/9 [00:00<?, ?it/s]\u001b[A\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            " 22%|██████████████▍                                                  | 2/9 [00:52<03:03, 26.21s/it]\u001b[A\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            " 33%|█████████████████████▋                                           | 3/9 [01:06<02:15, 22.55s/it]\u001b[A\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            " 44%|████████████████████████████▉                                    | 4/9 [01:17<01:35, 19.12s/it]\u001b[A\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            " 56%|████████████████████████████████████                             | 5/9 [01:28<01:07, 16.78s/it]\u001b[A\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            " 67%|███████████████████████████████████████████▎                     | 6/9 [01:40<00:45, 15.19s/it]\u001b[A\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            " 78%|██████████████████████████████████████████████████▌              | 7/9 [01:52<00:28, 14.16s/it]\u001b[A\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            " 89%|█████████████████████████████████████████████████████████▊       | 8/9 [02:03<00:13, 13.44s/it]\u001b[A\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n",
+            "100%|█████████████████████████████████████████████████████████████████| 9/9 [02:26<00:00, 16.06s/it]\u001b[A\u001b[A\u001b[A\u001b[A\u001b[A\n",
+            "\n",
+            " *** Finished the prediction in: 0 hours and 2 minutes and 29.7 seconds.\n",
+            " *** Detected: 1559 events.\n",
+            " *** Wrote the results into --> \" /content/detections/SV08_outputs \"\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 576x432 with 0 Axes>"
+            ]
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "hRmeziYiZDSG"
+      },
+      "source": [
+        "This will generate one `station_name.hdf5` and one `station_name.csv` file for each of your station’s data and put them into a directory named mseed_dir+_hdfs. Then you need to pass the name of this directory (which contains all of your hdf5 & CSV files) and a model to the following command:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 1000
+        },
+        "id": "Sedrw-BtLhkK",
+        "outputId": "0f786fbc-615d-4b13-b151-c63cac619bdf"
+      },
+      "source": [
+        "from EQTransformer.core.mseed_predictor import mseed_predictor\n",
+        "\n",
+        "mseed_predictor(input_dir='downloads_mseeds',   \n",
+        "                input_model='EQTransformer/ModelsAndSampleData/EqT_model.h5',\n",
+        "                stations_json='json/station_list.json',\n",
+        "                output_dir='detection_results',\n",
+        "                detection_threshold=0.2,                \n",
+        "                P_threshold=0.1,\n",
+        "                S_threshold=0.1, \n",
+        "                number_of_plots=10,\n",
+        "                plot_mode='time_frequency',\n",
+        "                batch_size=500,\n",
+        "                overlap=0.3)"
+      ],
+      "execution_count": 8,
+      "outputs": [
+        {
+          "metadata": {
+            "tags": null
+          },
+          "name": "stderr",
+          "output_type": "stream",
+          "text": [
+            "11-14 23:41 [INFO] [EQTransformer] Running EqTransformer  0.1.61\n",
+            "11-14 23:41 [INFO] [EQTransformer] *** Loading the model ...\n",
+            "11-14 23:41 [INFO] [EQTransformer] *** Loading is complete!\n",
+            "11-14 23:41 [INFO] [EQTransformer] *** /content/detection_results already exists!\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            " --> Type (Yes or y) to create a new empty directory! This will erase your previous results so make a copy if you want them.y\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "11-15 01:25 [INFO] [EQTransformer] There are files for 3 stations in downloads_mseeds directory.\n",
+            "11-15 01:25 [INFO] [EQTransformer] Started working on B921, 1 out of 3 ...\n",
+            "11-15 01:25 [INFO] [EQTransformer] 20190901T000000Z__20190902T000000Z.mseed\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: Matching serif:style=normal:variant=normal:weight=normal:stretch=condensed:size=12.0.\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Sans Mono' (DejaVuSansMono-Bold.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Sans Display' (DejaVuSansDisplay.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Sans' (DejaVuSans.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Serif' (DejaVuSerif-Italic.ttf) italic normal 400 normal>) = 1.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXSizeFourSym' (STIXSizFourSymBol.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXSizeFourSym' (STIXSizFourSymReg.ttf) normal normal regular normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXNonUnicode' (STIXNonUni.ttf) normal normal regular normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'cmss10' (cmss10.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXSizeOneSym' (STIXSizOneSymBol.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXSizeThreeSym' (STIXSizThreeSymBol.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXGeneral' (STIXGeneralItalic.ttf) italic normal 400 normal>) = 11.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXNonUnicode' (STIXNonUniIta.ttf) italic normal 400 normal>) = 11.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXSizeFiveSym' (STIXSizFiveSymReg.ttf) normal normal regular normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXGeneral' (STIXGeneralBolIta.ttf) italic normal 700 normal>) = 11.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Sans Mono' (DejaVuSansMono-BoldOblique.ttf) oblique normal 700 normal>) = 11.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Sans Mono' (DejaVuSansMono-Oblique.ttf) oblique normal 400 normal>) = 11.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Serif Display' (DejaVuSerifDisplay.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Sans' (DejaVuSans-Oblique.ttf) oblique normal 400 normal>) = 11.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'cmsy10' (cmsy10.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXNonUnicode' (STIXNonUniBolIta.ttf) italic normal 700 normal>) = 11.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXSizeTwoSym' (STIXSizTwoSymReg.ttf) normal normal regular normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'cmmi10' (cmmi10.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Sans' (DejaVuSans-BoldOblique.ttf) oblique normal 700 normal>) = 11.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Serif' (DejaVuSerif.ttf) normal normal 400 normal>) = 0.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Serif' (DejaVuSerif-BoldItalic.ttf) italic normal 700 normal>) = 1.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXGeneral' (STIXGeneralBol.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Serif' (DejaVuSerif-Bold.ttf) normal normal 700 normal>) = 0.5349999999999999\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXGeneral' (STIXGeneral.ttf) normal normal regular normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXSizeOneSym' (STIXSizOneSymReg.ttf) normal normal regular normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'cmr10' (cmr10.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXSizeTwoSym' (STIXSizTwoSymBol.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'cmtt10' (cmtt10.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Sans Mono' (DejaVuSansMono.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'cmex10' (cmex10.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'DejaVu Sans' (DejaVuSans-Bold.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'cmb10' (cmb10.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXNonUnicode' (STIXNonUniBol.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'STIXSizeThreeSym' (STIXSizThreeSymReg.ttf) normal normal regular normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Sans' (LiberationSans-Italic.ttf) italic normal 400 normal>) = 11.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Mono' (LiberationMono-Italic.ttf) italic normal 400 normal>) = 11.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Humor Sans' (Humor-Sans.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Sans Narrow' (LiberationSansNarrow-Regular.ttf) normal normal 400 condensed>) = 10.05\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Mono' (LiberationMono-BoldItalic.ttf) italic normal 700 normal>) = 11.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Sans Narrow' (LiberationSansNarrow-BoldItalic.ttf) italic normal 700 condensed>) = 11.335\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Sans Narrow' (LiberationSansNarrow-Italic.ttf) italic normal 400 condensed>) = 11.05\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Serif' (LiberationSerif-Regular.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Mono' (LiberationMono-Bold.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Sans' (LiberationSans-Regular.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Sans Narrow' (LiberationSansNarrow-Bold.ttf) normal normal 700 condensed>) = 10.335\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Serif' (LiberationSerif-Bold.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Serif' (LiberationSerif-BoldItalic.ttf) italic normal 700 normal>) = 11.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Sans' (LiberationSans-Bold.ttf) normal normal 700 normal>) = 10.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Sans' (LiberationSans-BoldItalic.ttf) italic normal 700 normal>) = 11.535\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Mono' (LiberationMono-Regular.ttf) normal normal 400 normal>) = 10.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: score(<Font 'Liberation Serif' (LiberationSerif-Italic.ttf) italic normal 400 normal>) = 11.25\n",
+            "11-15 01:26 [DEBUG] [matplotlib.font_manager] findfont: Matching serif:style=normal:variant=normal:weight=normal:stretch=condensed:size=12.0 to DejaVu Serif ('/usr/local/lib/python3.7/dist-packages/matplotlib/mpl-data/fonts/ttf/DejaVuSerif.ttf') with score of 0.250000.\n",
+            "11-15 01:26 [INFO] [EQTransformer] 20190902T000000Z__20190903T000000Z.mseed\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "11-15 01:27 [INFO] [EQTransformer] Finished the prediction in: 0 hours and 1 minutes and 51.34 seconds.\n",
+            "11-15 01:27 [INFO] [EQTransformer] *** Detected: 2926 events.\n",
+            "11-15 01:27 [INFO] [EQTransformer]  *** Wrote the results into --> \" /content/detection_results/B921_outputs \"\n",
+            "11-15 01:27 [INFO] [EQTransformer] Started working on CA06, 2 out of 3 ...\n",
+            "11-15 01:27 [INFO] [EQTransformer] 20190901T000000Z__20190902T000000Z.mseed\n",
+            "11-15 01:27 [INFO] [EQTransformer] 20190902T000000Z__20190903T000000Z.mseed\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "11-15 01:28 [INFO] [EQTransformer] Finished the prediction in: 0 hours and 1 minutes and 25.2 seconds.\n",
+            "11-15 01:28 [INFO] [EQTransformer] *** Detected: 2879 events.\n",
+            "11-15 01:28 [INFO] [EQTransformer]  *** Wrote the results into --> \" /content/detection_results/CA06_outputs \"\n",
+            "11-15 01:28 [INFO] [EQTransformer] Started working on SV08, 3 out of 3 ...\n",
+            "11-15 01:28 [INFO] [EQTransformer] 20190901T000000Z__20190902T000000Z.mseed\n",
+            "11-15 01:29 [INFO] [EQTransformer] 20190902T000000Z__20190903T000000Z.mseed\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "11-15 01:29 [INFO] [EQTransformer] Finished the prediction in: 0 hours and 1 minutes and 22.6 seconds.\n",
+            "11-15 01:29 [INFO] [EQTransformer] *** Detected: 1648 events.\n",
+            "11-15 01:29 [INFO] [EQTransformer]  *** Wrote the results into --> \" /content/detection_results/SV08_outputs \"\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 720x720 with 0 Axes>"
+            ]
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BpD0pIq2ZOuj"
+      },
+      "source": [
+        "## Option (II) directly from mseed files:\n",
+        "You can perform the detection & phase picking directly on downloaded MiniSeed files. This saves both preprocessing time and the extra space needed for the hdf5 file and is recommended for larger (longer) datasets. However, it can be more memory intensive. So it is better to have your MiniSeed fils being shorter than one month or so.\n",
+        "\n",
+        "This option also does not allow you to estimate the uncertainties, save the prediction probabilities, or use the advantages of having hdf5 files which makes it easy to access the raw event waveforms based on detection results."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "lrqn9z0-LKu6"
+      },
+      "source": [
+        "from EQTransformer.core.mseed_predictor import mseed_predictor"
+      ],
+      "execution_count": 9,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 544
+        },
+        "id": "RX2DROQkKxU8",
+        "outputId": "a30874cf-ff9a-4b0c-c3ab-c263e52f3bc5"
+      },
+      "source": [
+        "\n",
+        "mseed_predictor(input_dir='downloads_mseeds',   \n",
+        "                input_model='EQTransformer/ModelsAndSampleData/EqT_model.h5',\n",
+        "                stations_json='jason/station_list.json',\n",
+        "                output_dir='detection_results',\n",
+        "                detection_threshold=0.2,                \n",
+        "                P_threshold=0.1,\n",
+        "                S_threshold=0.1, \n",
+        "                number_of_plots=10,\n",
+        "                plot_mode='time_frequency',\n",
+        "                batch_size=500,\n",
+        "                overlap=0.3)"
+      ],
+      "execution_count": 10,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "11-15 01:35 [INFO] [EQTransformer] Running EqTransformer  0.1.61\n",
+            "11-15 01:35 [INFO] [EQTransformer] *** Loading the model ...\n",
+            "11-15 01:35 [INFO] [EQTransformer] *** Loading is complete!\n",
+            "11-15 01:35 [INFO] [EQTransformer] *** /content/detection_results already exists!\n"
+          ]
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            " --> Type (Yes or y) to create a new empty directory! This will erase your previous results so make a copy if you want them.y\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "11-15 01:35 [INFO] [EQTransformer] There are files for 3 stations in downloads_mseeds directory.\n",
+            "11-15 01:35 [INFO] [EQTransformer] Started working on B921, 1 out of 3 ...\n",
+            "11-15 01:35 [INFO] [EQTransformer] 20190901T000000Z__20190902T000000Z.mseed\n",
+            "11-15 01:36 [INFO] [EQTransformer] 20190902T000000Z__20190903T000000Z.mseed\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "11-15 01:36 [INFO] [EQTransformer] Finished the prediction in: 0 hours and 1 minutes and 32.14 seconds.\n",
+            "11-15 01:36 [INFO] [EQTransformer] *** Detected: 2946 events.\n",
+            "11-15 01:36 [INFO] [EQTransformer]  *** Wrote the results into --> \" /content/detection_results/B921_outputs \"\n",
+            "11-15 01:36 [INFO] [EQTransformer] Started working on CA06, 2 out of 3 ...\n",
+            "11-15 01:36 [INFO] [EQTransformer] 20190901T000000Z__20190902T000000Z.mseed\n",
+            "11-15 01:37 [INFO] [EQTransformer] 20190902T000000Z__20190903T000000Z.mseed\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "11-15 01:38 [INFO] [EQTransformer] Finished the prediction in: 0 hours and 1 minutes and 25.18 seconds.\n",
+            "11-15 01:38 [INFO] [EQTransformer] *** Detected: 2862 events.\n",
+            "11-15 01:38 [INFO] [EQTransformer]  *** Wrote the results into --> \" /content/detection_results/CA06_outputs \"\n",
+            "11-15 01:38 [INFO] [EQTransformer] Started working on SV08, 3 out of 3 ...\n",
+            "11-15 01:38 [INFO] [EQTransformer] 20190901T000000Z__20190902T000000Z.mseed\n",
+            "11-15 01:39 [INFO] [EQTransformer] 20190902T000000Z__20190903T000000Z.mseed\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "\n",
+            "\n"
+          ]
+        },
+        {
+          "output_type": "stream",
+          "name": "stderr",
+          "text": [
+            "11-15 01:39 [INFO] [EQTransformer] Finished the prediction in: 0 hours and 1 minutes and 23.81 seconds.\n",
+            "11-15 01:39 [INFO] [EQTransformer] *** Detected: 1672 events.\n",
+            "11-15 01:39 [INFO] [EQTransformer]  *** Wrote the results into --> \" /content/detection_results/SV08_outputs \"\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<Figure size 720x720 with 0 Axes>"
+            ]
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "scbAYKdLOBT-"
+      },
+      "source": [
+        ""
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Thanks for your amazing Python package EQTransformer.
I noticed that installing EQT via Google Colab by:
 ```pip install git+https://github.com/smousavi05/EQTransformer```
will raise an error:
```
ERROR: Cannot install EQTransformer and eqtransformer==0.1.61 because these package versions have conflicting dependencies.
```
Thus, I upload a more detailed version of how to install EQT on Google Colab. I didn't do any change on the original repo but only in the newly uploaded Colab notebook: e.g., rewrite the package versions EQT specified about NumPy; add full folder directory of the pre-trained model file. And it will work successfully on Google Colab. Please take a look at it, and hope it would help.