### PR TITLE
resolve dependency conflict (tensorflow vs. numpy)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+pytest
+numpy~=1.19.2
+keyring>=15.1
+pkginfo>=1.4.2
+scipy>=1.4.1
+tensorflow~=2.5.0
+keras~=2.3.1
+matplotlib
+pandas
+tqdm>=4.48.0
+h5py~=3.1.0
+obspy
+jupyter 
+

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,16 @@ setup(
     keywords='Seismology, Earthquakes Detection, P&S Picking, Deep Learning, Attention Mechanism',
     install_requires=[
 	'pytest',
-	'numpy>=1.20.3',
+	'numpy~=1.19.2',     # appox version: numpy 1.19.x but at least 1.19.2
 	'keyring>=15.1', 
 	'pkginfo>=1.4.2',
 	'scipy>=1.4.1', 
-	'tensorflow==2.5.2', 
+	'tensorflow~=2.5.0', # tensorflow <2.7.0 needs numpy <1.20.0
 	'keras==2.3.1', 
 	'matplotlib', 
 	'pandas',
 	'tqdm>=4.48.0', 
-	'h5py>=3.1.0', 
+	'h5py~=3.1.0', 
 	'obspy',
 	'jupyter'], 
 


### PR DESCRIPTION
Tensorflow < 2.7.0 is incompatible with numpy 1.20.0 and newer.
Therefore I'm setting the numpy version to numpy~=1.19.2
(i.e. any version 1.19.x but at least 1.19.2) as this is the
version used in EQTransformerviaGoogleColab.ipynb.

Also set TF to tensorflow~=2.5.0 so that it can be used
with any 2.5.x version.

Also add `requirements.txt` with the same definitions, so that dependencies can be installed with:
```
pip install -r requirements.txt
```


Addresses: #99