### PR TITLE
Installing Obspy prior to eqtransformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Developer: S. Mostafa Mousavi (smousavi05@gmail.com)
 
     conda activate eqt
 
+    conda install conda-forge::obspy
+
     conda install -c smousavi05 eqtransformer 
     
 ##### Note: sometimes you need to keep repeating executing the last line multiple time to succeed.  

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The sources for **EQTransformer** can be downloaded from the `GitHub repo`.
 
 You can either clone the public repository:
 
-    git clone git://github.com/smousavi05/EQTransformer
+    git clone https://github.com/smousavi05/EQTransformer.git
     
 or (if you are working on Colab)
 


### PR DESCRIPTION
When installing it on my Mac machine and a Linux-based HPC, I need to install obspy first.